### PR TITLE
Added correct Datetimeformat Parsing for ECS response

### DIFF
--- a/AWSSDK/Amazon.S3/Model/S3Object.cs
+++ b/AWSSDK/Amazon.S3/Model/S3Object.cs
@@ -144,7 +144,7 @@ namespace Amazon.S3.Model
             {
                 this.lastModified = DateTime.ParseExact(
                     value,
-                    new string[] { AWSSDKUtils.ISO8601DateFormat, AWSSDKUtils.GMTDateFormat },
+                    new string[] { AWSSDKUtils.ISO8601DateFormat, AWSSDKUtils.ISO8601DateFormatNoMS, AWSSDKUtils.GMTDateFormat },
                     CultureInfo.InvariantCulture,
                     DateTimeStyles.None
                     );


### PR DESCRIPTION
AmazonS3.ListObjects response uses AWSSDKUtils.ISO8601DateFormatNoMS as the datetimeformat for S3Object.LastModified in ECS